### PR TITLE
Remove warning raised from Next

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import Audio, { PlayOptions } from "../lib/audio";
 
-export default () => {
+const App = () => {
   const [audio, setAudio] = useState<Audio | null>(null);
   const [isDraggingOver, setIsDraggingOver] = useState(false);
   const [playOptions, setPlayOptions] = useState<PlayOptions>({
@@ -138,3 +138,5 @@ export default () => {
     </div>
   );
 };
+
+export default App;


### PR DESCRIPTION
Remove warning raised from Next

```
warn  - ./pages/index.tsx
Anonymous arrow functions cause Fast Refresh to not preserve local component state.
Please add a name to your function, for example:

Before
export default () => <div />;

After
const Named = () => <div />;
export default Named;

A codemod is available to fix the most common cases: https://nextjs.link/codemod-ndc
```